### PR TITLE
Fix vallox object init preventing start

### DIFF
--- a/MQTT_config.py
+++ b/MQTT_config.py
@@ -1,4 +1,0 @@
-ip_address = "IP_ADDRESS_OF_BROKER"
-topic = "homeassistant/sensor/vallox"
-username = "MQTT_USERNAME"
-password = "MQTT_PASSWORD"

--- a/Serial_config.py
+++ b/Serial_config.py
@@ -1,5 +1,3 @@
-SERIAL_PORT = "/dev/ttyS0"
-
 SENTENCE_START = b"\x01"
 
 SENTENCE_SYSTEM = b"\x11"

--- a/Vallox_communicator.py
+++ b/Vallox_communicator.py
@@ -89,7 +89,7 @@ class Vallox:
 
 
 if __name__ == "__main__":
-    vallox = Vallox(MQTT_BROKER, MQTT_TOPIC, MQTT_USERNAME, MQTT_PASSWORD, SERIAL_PORT)
+    vallox = Vallox()
     vallox.subscribe()
     monitor = threading.Thread(target=vallox.monitor_values)
     monitor.start()

--- a/tests/test_vallox.py
+++ b/tests/test_vallox.py
@@ -11,7 +11,7 @@ class TestVallox(unittest.TestCase):
     def test_init(self, mock_serial, mock_mqtt):
         vallox = Vallox()
 
-        self.assertEqual(vallox.topic, "vallox")
+        self.assertEqual(vallox.topic, "homeassistant/sensor/vallox")
         self.assertEqual(vallox.serial, mock_serial.return_value)
         self.assertEqual(vallox.client, mock_mqtt.return_value)
         mock_mqtt.return_value.username_pw_set.assert_called_once_with(
@@ -47,7 +47,7 @@ class TestVallox(unittest.TestCase):
 
         self.assertEqual(vallox.counter, 1)  # Counter should reset
         mock_publish.assert_called_once_with(
-            "vallox", str(json.dumps(vallox.vallox_data))
+            "homeassistant/sensor/vallox", str(json.dumps(vallox.vallox_data))
         )
 
     @patch("Vallox_communicator.mqtt.Client", autospec=True)

--- a/vallox_config.py
+++ b/vallox_config.py
@@ -2,39 +2,12 @@
 
 # MQTT Configuration
 MQTT_BROKER = "mqtt://your-mqtt-broker-url"  # Replace with your MQTT broker URL
-MQTT_TOPIC = "vallox"  # Replace with your MQTT topic
+MQTT_TOPIC = "homeassistant/sensor/vallox"  # Replace with your MQTT topic
 MQTT_USERNAME = "your-mqtt-username"  # Replace with your MQTT username
 MQTT_PASSWORD = "your-mqtt-password"  # Replace with your MQTT password
 
 # Serial Port Configuration
 SERIAL_PORT = (
-    "/dev/ttyUSB0"  # Replace with the serial port your Vallox device is connected to
+    "/dev/ttyS0"  # Replace with the serial port your Vallox device is connected to
 )
 BAUD_RATE = 9600
-
-# Define temperature identifiers and lookup values
-TEMP_IDENTIFIERS = {
-    0: "TEMP_0",
-    1: "TEMP_1",
-    # Add more temperature identifiers as needed
-}
-
-TEMP_LOOKUP = {
-    0: 20.0,
-    1: 22.5,
-    # Add more temperature lookup values as needed
-}
-
-# Define fan speed lookup values
-FANSPEED_LOOKUP = {
-    0: "LOW",
-    1: "MEDIUM",
-    2: "HIGH",
-}
-
-# Define fan speed settings
-FANSPEED_SET = {
-    "LOW": b"\x01",
-    "MEDIUM": b"\x02",
-    "HIGH": b"\x03",
-}


### PR DESCRIPTION
Fix vallox object init by removing unnecessary inputs
Remove unused file MQTT_config.py and unused stuff from used config files.